### PR TITLE
Allow errors for less keys

### DIFF
--- a/src/components/question.js
+++ b/src/components/question.js
@@ -50,7 +50,7 @@ export class Question extends Component {
           questionComplete(score, incorrectAttempts);
           this.reset()
         } else {
-          this.handleIncorrect();
+          // this.handleIncorrect();
         }
       }
     }
@@ -63,10 +63,24 @@ export class Question extends Component {
 
     // Decrement number of keys down by 1
     // Do not allows number of keys down to be less than 1
-    if (numOfKeysDown > 0) newNumOfKeysDown = numOfKeysDown - 1;
+    if (numOfKeysDown > 0) {
+      console.log('num of keys updated', e.key);
+      // newNumOfKeysDown = numOfKeysDown - 1;
+      newNumOfKeysDown -= 1;
+    }
+
+    if (this.state.currentKeys.includes("Meta") && this.state.currentKeys.length > 1) {
+      console.log('inside extra condition');
+      newNumOfKeysDown -= 1;
+    }
+
+    console.log('newNumOfKeysDown, e.key, this.state.currentKeys', newNumOfKeysDown, e.key, this.state.currentKeys)
 
     // Handle incorrect if there are no keys down, and we have not just completed a question
-    if (!justCompletedQuestion && newNumOfKeysDown === 0) this.handleIncorrect();
+    if (!justCompletedQuestion && newNumOfKeysDown === 0) {
+      console.log('---- INCORRECT!!!!! ----', justCompletedQuestion, newNumOfKeysDown)
+      this.handleIncorrect();
+    }
 
     this.setState({
       currentKeys: [],
@@ -111,7 +125,7 @@ export class Question extends Component {
     arr2.sort();
 
     for (let i = 0; i < arr1.length; i++) {
-      if (arr1[i].toLowerCase() !== arr2[i].toLowerCase()) return false;
+      if (arr1[i] !== arr2[i]) return false;
     }
     return true;
   }

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -145,7 +145,8 @@ export class Question extends Component {
     arr2.sort();
 
     for (let i = 0; i < arr1.length; i++) {
-      if (arr1[i] !== arr2[i]) return false;
+      if (!arr1[i]) return false;
+      if (arr1[i].toLowerCase() !== arr2[i].toLowerCase()) return false;
     }
     return true;
   }

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -45,7 +45,7 @@ export class Question extends Component {
 
       if (newKeys.length === shortcut.combo.length) {
         if (this.compareArrays(newKeys, shortcut.combo)) {
-          // Set justCompletedQuestion to true
+          // Set justCompletedQuestion to true and clear the number of keysDown
           this.setState({justCompletedQuestion: true, keysDown: 0})
           questionComplete(score, incorrectAttempts);
           this.reset()

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -3,6 +3,12 @@ import QuestionFeedback from "./questionFeedback";
 
 const INITIAL_SCORE = 5;
 const SCORE_DECREMENT = 2;
+const powerKeys = {
+  "Meta": true,
+  "Shift": true,
+  "Alt": true,
+  "Control": true
+}
 
 export class Question extends Component {
   constructor(props) {
@@ -64,14 +70,22 @@ export class Question extends Component {
     // Decrement number of keys down by 1
     // Do not allows number of keys down to be less than 1
     if (numOfKeysDown > 0) {
-      console.log('num of keys updated', e.key);
+      console.log('num of keys updated', e.key, numOfKeysDown, numOfKeysDown - 1);
       // newNumOfKeysDown = numOfKeysDown - 1;
       newNumOfKeysDown -= 1;
     }
 
     if (this.state.currentKeys.includes("Meta") && this.state.currentKeys.length > 1) {
-      console.log('inside extra condition');
-      newNumOfKeysDown -= 1;
+      let extraDecrement = 0;
+      console.log('inside extra condition', extraDecrement, this.state.currentKeys);
+      for (let i = 0; i < this.state.currentKeys.length; i++) {
+        console.log('INSIDE LOOP');
+        console.log('this.state.currentKeys[i]', this.state.currentKeys[i]);
+        if (!powerKeys[this.state.currentKeys[i]]) {
+          extraDecrement += 1;
+        }
+      }
+      newNumOfKeysDown -= extraDecrement;
     }
 
     console.log('newNumOfKeysDown, e.key, this.state.currentKeys', newNumOfKeysDown, e.key, this.state.currentKeys)
@@ -81,6 +95,8 @@ export class Question extends Component {
       console.log('---- INCORRECT!!!!! ----', justCompletedQuestion, newNumOfKeysDown)
       this.handleIncorrect();
     }
+
+
 
     this.setState({
       currentKeys: [],

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -11,6 +11,8 @@ export class Question extends Component {
       currentKeys: [],
       score: INITIAL_SCORE,
       incorrectAttempts: 0,
+      justCompletedQuestion: false,
+      keysDown: 0
     };
   }
 
@@ -25,14 +27,22 @@ export class Question extends Component {
   }
 
   keyDown = (e) => {
+    const { justCompletedQuestion } = this.state;
+
     e.preventDefault();
     if (!e.repeat) {
+      this.setState({keysDown: this.state.keysDown + 1});
+      if (justCompletedQuestion) {
+        this.setState({justCompletedQuestion: false})
+      }
       const newKeys = [...this.state.currentKeys, e.key];
       this.setState({
         currentKeys: newKeys,
       });
       if (newKeys.length === this.props.shortcut.combo.length) {
         if (this.compareArrays(newKeys, this.props.shortcut.combo)) {
+          console.log('just won!', this.state.currentKeys)
+          this.setState({justCompletedQuestion: true, keysDown: 0})
           this.props.questionComplete(this.state.score, this.state.incorrectAttempts);
           this.reset()
         } else {
@@ -42,10 +52,41 @@ export class Question extends Component {
     }
   };
 
+  removeItemFromArray = (array, item) => {
+    let index = array.indexOf(item);
+    if (index > -1) {
+      array.splice(index, 1);
+    }
+
+    return array;
+  }
+
   keyUp = (e) => {
     e.preventDefault();
+    let { currentKeys, justCompletedQuestion, keysDown } = this.state;
+    let keysComparison = keysDown
+    if (keysDown > 0) {
+      keysComparison = keysDown - 1;
+    }
+    console.log('keysDown, keysComparison', currentKeys, keysDown, keysComparison)
+    this.setState({keysDown: keysComparison});
+    // currentKeys = [...new Set(currentKeys)];
+
+    // console.log('e.key', e.key);
+    // console.log('this.state.currentKeys', this.state.currentKeys);
+
+    // this.removeItemFromArray(currentKeys, e.key);
+    // currentKeys.pop();
+    // console.log('this.state.currentKeys, e.key', currentKeys, e.key);
+
+    // this.state.currentKeys.splice(keyIndex, 1);
+
+    if (!justCompletedQuestion && keysComparison === 0) {
+      this.handleIncorrect();
+    }
     this.setState({
       currentKeys: [],
+      // justCompletedQuestion: false,
     });
   };
 
@@ -86,7 +127,7 @@ export class Question extends Component {
     arr2.sort();
 
     for (let i = 0; i < arr1.length; i++) {
-      if (arr1[i] !== arr2[i]) return false;
+      if (arr1[i].toLowerCase() !== arr2[i].toLowerCase()) return false;
     }
     return true;
   }

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -51,26 +51,18 @@ export class Question extends Component {
     }
   };
 
-  removeItemFromArray = (array, item) => {
-    let index = array.indexOf(item);
-    if (index > -1) {
-      array.splice(index, 1);
-    }
-
-    return array;
-  }
-
   keyUp = (e) => {
     e.preventDefault();
     let { justCompletedQuestion, keysDown } = this.state;
     let keysComparison = keysDown
-    if (keysDown > 0) {
-      keysComparison = keysDown - 1;
-    }
 
-    if (!justCompletedQuestion && keysComparison === 0) {
-      this.handleIncorrect();
-    }
+    // Decrement number of keys down by 1
+    // Do not allows number of keys down to be less than 1
+    if (keysDown > 0) keysComparison = keysDown - 1;
+
+    // Handle incorrect if there are no keys down, and we have not just completed a question
+    if (!justCompletedQuestion && keysComparison === 0) this.handleIncorrect();
+
     this.setState({
       currentKeys: [],
       keysDown: keysComparison

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -41,7 +41,6 @@ export class Question extends Component {
       });
       if (newKeys.length === this.props.shortcut.combo.length) {
         if (this.compareArrays(newKeys, this.props.shortcut.combo)) {
-          console.log('just won!', this.state.currentKeys)
           this.setState({justCompletedQuestion: true, keysDown: 0})
           this.props.questionComplete(this.state.score, this.state.incorrectAttempts);
           this.reset()
@@ -63,30 +62,18 @@ export class Question extends Component {
 
   keyUp = (e) => {
     e.preventDefault();
-    let { currentKeys, justCompletedQuestion, keysDown } = this.state;
+    let { justCompletedQuestion, keysDown } = this.state;
     let keysComparison = keysDown
     if (keysDown > 0) {
       keysComparison = keysDown - 1;
     }
-    console.log('keysDown, keysComparison', currentKeys, keysDown, keysComparison)
-    this.setState({keysDown: keysComparison});
-    // currentKeys = [...new Set(currentKeys)];
-
-    // console.log('e.key', e.key);
-    // console.log('this.state.currentKeys', this.state.currentKeys);
-
-    // this.removeItemFromArray(currentKeys, e.key);
-    // currentKeys.pop();
-    // console.log('this.state.currentKeys, e.key', currentKeys, e.key);
-
-    // this.state.currentKeys.splice(keyIndex, 1);
 
     if (!justCompletedQuestion && keysComparison === 0) {
       this.handleIncorrect();
     }
     this.setState({
       currentKeys: [],
-      // justCompletedQuestion: false,
+      keysDown: keysComparison
     });
   };
 

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -12,7 +12,7 @@ export class Question extends Component {
       score: INITIAL_SCORE,
       incorrectAttempts: 0,
       justCompletedQuestion: false,
-      keysDown: 0
+      numOfKeysDown: 0
     };
   }
 
@@ -27,13 +27,13 @@ export class Question extends Component {
   }
 
   keyDown = (e) => {
-    const { justCompletedQuestion, currentKeys, keysDown, score, incorrectAttempts } = this.state;
+    const { justCompletedQuestion, currentKeys, numOfKeysDown, score, incorrectAttempts } = this.state;
     const { shortcut, questionComplete } = this.props;
 
     e.preventDefault();
     if (!e.repeat) {
-      // Increment number of keysDown by 1
-      this.setState({keysDown: keysDown + 1});
+      // Increment number of numOfKeysDown by 1
+      this.setState({numOfKeysDown: numOfKeysDown + 1});
 
       // If we have just completed a question,
       // Set justCompletedQuestion to false on the first key down of the new question
@@ -45,8 +45,8 @@ export class Question extends Component {
 
       if (newKeys.length === shortcut.combo.length) {
         if (this.compareArrays(newKeys, shortcut.combo)) {
-          // Set justCompletedQuestion to true and clear the number of keysDown
-          this.setState({justCompletedQuestion: true, keysDown: 0})
+          // Set justCompletedQuestion to true and clear the number of numOfKeysDown
+          this.setState({justCompletedQuestion: true, numOfKeysDown: 0})
           questionComplete(score, incorrectAttempts);
           this.reset()
         } else {
@@ -58,19 +58,19 @@ export class Question extends Component {
 
   keyUp = (e) => {
     e.preventDefault();
-    let { justCompletedQuestion, keysDown } = this.state;
-    let keysComparison = keysDown
+    let { justCompletedQuestion, numOfKeysDown } = this.state;
+    let newNumOfKeysDown = numOfKeysDown
 
     // Decrement number of keys down by 1
     // Do not allows number of keys down to be less than 1
-    if (keysDown > 0) keysComparison = keysDown - 1;
+    if (numOfKeysDown > 0) newNumOfKeysDown = numOfKeysDown - 1;
 
     // Handle incorrect if there are no keys down, and we have not just completed a question
-    if (!justCompletedQuestion && keysComparison === 0) this.handleIncorrect();
+    if (!justCompletedQuestion && newNumOfKeysDown === 0) this.handleIncorrect();
 
     this.setState({
       currentKeys: [],
-      keysDown: keysComparison
+      numOfKeysDown: newNumOfKeysDown
     });
   };
 

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -27,22 +27,27 @@ export class Question extends Component {
   }
 
   keyDown = (e) => {
-    const { justCompletedQuestion } = this.state;
+    const { justCompletedQuestion, currentKeys, keysDown, score, incorrectAttempts } = this.state;
+    const { shortcut, questionComplete } = this.props;
 
     e.preventDefault();
     if (!e.repeat) {
-      this.setState({keysDown: this.state.keysDown + 1});
-      if (justCompletedQuestion) {
-        this.setState({justCompletedQuestion: false})
-      }
-      const newKeys = [...this.state.currentKeys, e.key];
-      this.setState({
-        currentKeys: newKeys,
-      });
-      if (newKeys.length === this.props.shortcut.combo.length) {
-        if (this.compareArrays(newKeys, this.props.shortcut.combo)) {
+      // Increment number of keysDown by 1
+      this.setState({keysDown: keysDown + 1});
+
+      // If we have just completed a question,
+      // Set justCompletedQuestion to false on the first key down of the new question
+      if (justCompletedQuestion) this.setState({justCompletedQuestion: false});
+
+      // Update the array of keys with the new key
+      const newKeys = [...currentKeys, e.key];
+      this.setState({currentKeys: newKeys});
+
+      if (newKeys.length === shortcut.combo.length) {
+        if (this.compareArrays(newKeys, shortcut.combo)) {
+          // Set justCompletedQuestion to true
           this.setState({justCompletedQuestion: true, keysDown: 0})
-          this.props.questionComplete(this.state.score, this.state.incorrectAttempts);
+          questionComplete(score, incorrectAttempts);
           this.reset()
         } else {
           this.handleIncorrect();
@@ -89,7 +94,7 @@ export class Question extends Component {
   render() {
     const { incorrectAttempts } = this.state;
     const { hint } = this.props.shortcut;
-    const length = this.props.shortcut.hint.length
+    const length = this.props.shortcut.hint.length;
     return (
       <div>
         <h2>{this.props.shortcut.name}</h2>

--- a/src/components/question.test.js
+++ b/src/components/question.test.js
@@ -200,8 +200,8 @@ it(".compareArrays compares arrays", () => {
   const wrapper = shallow(<Question shortcut={mockShortcut} />);
   const instance = wrapper.instance()
 
-  const arr1 = [1,2]
-  const arr2 = [1,2, 3]
+  const arr1 = ["1", "2"]
+  const arr2 = ["1", "2", "3"]
   const arr3 = ["a","b", "c"]
   const arr4 = ["a","b", "c"]
 


### PR DESCRIPTION
There has been a problem with our game, where gameplay is awkward, as for a 4 key combination if you press 3 keys, you won't get a failure. And because you don't get a failure, you don't get given a hint.

This update means, that if you press the wrong key combination, and that key combination has fewer keys that the target combination, you get a failure for 1 attempt.

Previous attempts at this caused a problem, where when the users successfully answer a question, they would then get failures for the next question as they lift the keys up.

This fixes this problem by adding two new items to state:

1. `justCompletedQuestion` -> this is set to true whenever a question is completed, and then back to false when a user presses their first next key on that question. We then use this value to prevent question failures being triggered on key up after a successful answer.
2. `numOfKeysDown` -> this is the number of keys down. This is used to prevent a failure being triggered on each individual key up. Instead, a failure is only triggered when the last key is lifted up, i.e. when `numOfKeysDown === 0`.

There are two new functions to handle the updating of `numOfKeysDown`:
1. `findNewNumOfKeysDown` -> this simply decrements the `numOfKeys` by 1, and checks if the `handlePowerKeys` function should be called.
2. `handlePowerKeys` -> this deals with the special case that power keys are being held down, in which case `keyUp` is not triggered accept when power keys are lifted. This means we need some special logic to deal with that.

_**Important: Do you use windows? Then I need you to test how the `handlePowerKeys` function responds on windows! I don't know if it works the same there.**_

I hope you like this solution! 😄 